### PR TITLE
libarchive 3.6.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -86,10 +86,17 @@ test:
 
 about:
   home: https://libarchive.org/
-  summary: Multi-format archive and compression library
   license: BSD-2-Clause
   license_file: COPYING
   license_family: BSD
+  summary: Multi-format archive and compression library
+  description: |
+    Libarchive is an open-source BSD-licensed C programming library that provides streaming access 
+    to a variety of different archive formats, including tar, cpio, pax, Zip, and ISO9660 images. 
+    The distribution also includes bsdtar and bsdcpio, full-featured implementations of tar and cpio 
+    that use libarchive.
+    When reading archives, libarchive uses a robust automatic format detector that can automatically handle archives 
+    that have been compressed with gzip, bzip2, xz, lzip, and several other popular compression algorithms.
   dev_url: https://github.com/libarchive/libarchive
   doc_url: https://github.com/libarchive/libarchive/wiki
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.6.1" %}
+{% set version = "3.6.2" %}
 
 package:
   name: libarchive
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/libarchive/libarchive/releases/download/v{{ version }}/libarchive-{{ version }}.tar.gz
-  sha256: c676146577d989189940f1959d9e3980d28513d74eedfbc6b7f15ea45fe54ee2
+  sha256: ba6d02f15ba04aba9c23fd5f236bb234eab9d5209e95d1c4df85c44d5f19b9b3
   patches:
     - patches/0001-Add-lib-to-CMAKE_FIND_LIBRARY_PREFIXES-for-lzma.patch
     - patches/0003-VC9-compatibility-test-for-BCryptDeriveKeyPBKDF2.patch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -98,3 +98,6 @@ extra:
     - jakirkham
     - mingwandroid
     - ocefpaf
+  skip-lints:
+    - missing_tests
+    - host_section_needs_exact_pinnings


### PR DESCRIPTION
**Jira ticket:** [PKG-941](https://anaconda.atlassian.net/browse/PKG-941)

**The upstream data:**
Changelog: https://github.com/libarchive/libarchive/releases
[Diff between the latest and previous upstream releases](https://github.com/libarchive/libarchive/compare/3.6.1...3.6.2)
License: https://github.com/libarchive/libarchive/blob/master/COPYING
Requirements: https://github.com/libarchive/libarchive/blob/v3.6.2/CMakeLists.txt

**_Actions:_**

1. Add `description`

**_Notes:_**
 *  This release fixes [CVE-2022-36227](https://github.com/advisories/GHSA-gpgf-w78r-4pvj): NULL pointer dereference vulnerability in archive_write.c (https://github.com/libarchive/libarchive/issues/1754, https://github.com/libarchive/libarchive/pull/1759)

**Additional info:**

<details>

**Other checks:**

<details>

1. - [x] https://github.com/libarchive/libarchive/tree/v3.6.2 exists
2. - [ ] The upstream url error:
    https://libarchive.org/
    
3. - [ ] Check the pinnings
4. - [ ] Changelog url error:
    https://github.com/libarchive/libarchive/tree/v3.6.2
    200
5. - [ ] Additional research
    https://github.com/libarchive/libarchive/issues
    
6. - [ ] `dev_url` error:
    https://github.com/libarchive/libarchive
    
7. - [ ] `doc_url` error:
    https://github.com/libarchive/libarchive/wiki
    
8. - [ ] Verify that the `build_number` is correct
9. - [ ] Verify if the package needs `setuptools`
    
10. - [ ] Verify if the package needs `wheel`
    
11. - [ ] NO `pip` in test
    
12. - [ ] Verify the test section
13. - [ ] Verify if the package is `architecture specific`
14. - [ ] Verify that private modules are not mentioned in the recipe For example: (_private_module)
15.  - [x] license_file: COPYING is present

16. - [x] license_family BSD is present
17. - [x] License: BSD-2-Clause
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier          |
|:--------------------|
| BSD-2-Clause        |
| BSD-2-Clause-Patent |
| BSD-2-Clause-Views  |
</details>

**Check dependency issues:**

<details>
../aggregate/libarchive-feedstock/recipe/meta.yaml
Dependencies: ['zstd', 'xz', 'bzip2', 'lz4-c', 'zlib', 'libxml2']


noarch:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-ppc64le:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-s390x:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-arm64:
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

win-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

</details>

**Package Build Score: 11**


**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/libarchive-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/libarchive-feedstock/tree/3.6.2)
* [conda-forge recipe](https://github.com/{upstream}/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/libarchive)
* [Diff between upstream and feature branch](https://github.com/conda-forge/libarchive-feedstock/compare/main...AnacondaRecipes:3.6.2)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/libarchive-feedstock/compare/master...AnacondaRecipes:3.6.2)
* [The last merged PRs](https://github.com/AnacondaRecipes/libarchive-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)


</details>


**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 3.6.2 git@github.com:AnacondaRecipes/libarchive-feedstock.git
```
