### PR TITLE
libarchive 3.8.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "libarchive" %}
-{% set version = "3.8.1" %}
+{% set version = "3.8.2" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/{{ name }}/{{ name }}/releases/download/v{{ version }}/{{ name }}-{{ version }}.tar.gz
-  sha256: bde832a5e3344dc723cfe9cc37f8e54bde04565bfe6f136bc1bd31ab352e9fab
+  sha256: 5f2d3c2fde8dc44583a61165549dc50ba8a37c5947c90fc02c8e5ce7f1cfb80d
   patches:
     - patches/0001-Add-lib-to-CMAKE_FIND_LIBRARY_PREFIXES-for-lzma.patch
 


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-10282](https://anaconda.atlassian.net/browse/PKG-10282)
- [Upstream repository](http://github.com/libarchive/libarchive/tree/v3.8.2)
- [Upstream changelog/diff](https://github.com/libarchive/libarchive/releases)

### Explanation of changes:

- New version number
- Release note mentions addressing https://nvd.nist.gov/vuln/detail/CVE-2025-25724


[PKG-10282]: https://anaconda.atlassian.net/browse/PKG-10282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ