### PR TITLE
Fix win-64 libarchive 3.8.8 build and guard empty packages.

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -3,26 +3,6 @@ set LIB=%LIBRARY_LIB%;%LIB%
 set LIBPATH=%LIBRARY_LIB%;%LIBPATH%
 set INCLUDE=%LIBRARY_INC%;%INCLUDE%
 
-:: VS2008 doesn't have stdbool.h so copy in our own
-:: to 'lib' where the other headers are so it gets picked up.
-if "%VS_MAJOR%" == "9" (
-  if "%ARCH%" == "64" (
-::  The Windows 6.0A SDK does not provide the bcrypt.lib for 64-bit:
-::  C:\Program Files\Microsoft SDKs\Windows\v6.0A\Lib\x64
-::  .. yet does for 32-bit, oh well, this may disable password protected zip support.
-::  https://social.msdn.microsoft.com/Forums/windowsdesktop/en-US/673cc344-430c-4510-96e8-80b0bb42ae11/can-not-link-bcryptlib-to-an-64bit-build?forum=windowssdk
-    set ENABLE_CNG=NO
-  ) else (
-    set ENABLE_CNG=YES
-::  Have decided to standardise on *not* using bcrypt instead. If we update to the Windows Server 2008 SDK we could revisit this
-    set ENABLE_CNG=NO
-  )
-)
-
-:: libarchive >=3.8.8 uses BCrypt unconditionally on Windows; CMake only links
-:: bcrypt.lib when ENABLE_CNG is on (see upstream CMakeLists.txt).
-if not defined ENABLE_CNG set "ENABLE_CNG=YES"
-
 if "%vc%" NEQ "9" goto not_vc9
 :: This does not work yet:
 :: usage: cl [ option... ] filename... [ /link linkoption... ]
@@ -58,7 +38,7 @@ cmake -G "Ninja" ^
       -DCMAKE_C_USE_RESPONSE_FILE_FOR_OBJECTS:BOOL=FALSE ^
       -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
       -DCMAKE_C_FLAGS_RELEASE="%CFLAGS%" ^
-      -DENABLE_CNG=%ENABLE_CNG% ^
+      -DENABLE_CNG=ON ^
       -DENABLE_BZip2=ON ^
       -DBZIP2_ROOT=%PREFIX%/lib ^
      .

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -19,6 +19,10 @@ if "%VS_MAJOR%" == "9" (
   )
 )
 
+:: libarchive >=3.8.8 uses BCrypt unconditionally on Windows; CMake only links
+:: bcrypt.lib when ENABLE_CNG is on (see upstream CMakeLists.txt).
+if not defined ENABLE_CNG set "ENABLE_CNG=YES"
+
 if "%vc%" NEQ "9" goto not_vc9
 :: This does not work yet:
 :: usage: cl [ option... ] filename... [ /link linkoption... ]
@@ -55,7 +59,7 @@ cmake -G "Ninja" ^
       -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
       -DCMAKE_C_FLAGS_RELEASE="%CFLAGS%" ^
       -DENABLE_CNG=%ENABLE_CNG% ^
-      -DENABLE_BZIP2=TRUE ^
+      -DENABLE_BZip2=ON ^
       -DBZIP2_ROOT=%PREFIX%/lib ^
      .
 if errorlevel 1 exit /b 1
@@ -71,6 +75,11 @@ if errorlevel 1 exit /b 1
 echo "Installing..."
 ninja install
 if errorlevel 1 exit /b 1
+
+if not exist "%LIBRARY_BIN%\archive.dll" (
+  echo ERROR: %LIBRARY_BIN%\archive.dll was not installed
+  exit /b 1
+)
 
 :: Perform tests.
 echo "Testing..."

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - patches/0001-Add-lib-to-CMAKE_FIND_LIBRARY_PREFIXES-for-lzma.patch
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage('libarchive', max_pin='x.x') }}
   # macOS' native crypto gets used here, but the headers are needed
@@ -64,6 +64,11 @@ test:
     # Verify libraries are in place.
     - test -f "${PREFIX}/lib/libarchive.a"             # [unix]
     - test -f "${PREFIX}/lib/libarchive${SHLIB_EXT}"   # [unix]
+
+    # Verify Windows DLL and import library (guards against empty packages).
+    - if not exist "%LIBRARY_BIN%\archive.dll" exit /B 1  # [win]
+    - if not exist "%LIBRARY_LIB%\archive.lib" exit /B 1  # [win]
+    - if not exist "%LIBRARY_INC%\archive.h" exit /B 1  # [win]
 
     # Check for commands
     - bsdcat --version


### PR DESCRIPTION
Enable CNG/bcrypt linking required by upstream 3.8.8 on Windows, bump build number, and add win tests that archive.dll and related files are installed.

```
(dev) lundby@Mac libarchive-3.8.8-he4ea9ff_1 % tree
.
├── info
│   ├── about.json
│   ├── files
│   ├── git
│   ├── has_prefix
│   ├── hash_input.json
│   ├── index.json
│   ├── licenses
│   │   └── COPYING
│   ├── paths.json
│   ├── recipe
│   │   ├── bld.bat
│   │   ├── build.sh
│   │   ├── conda_build_config.yaml
│   │   ├── meta.yaml
│   │   ├── meta.yaml.template
│   │   ├── patches
│   │   │   └── 0001-Add-lib-to-CMAKE_FIND_LIBRARY_PREFIXES-for-lzma.patch
│   │   └── test-archives
│   │       ├── archive.7z
│   │       ├── hello_world.tar.zst
│   │       └── hello_world.xar
│   ├── run_exports.json
│   └── test
│       ├── run_test.bat
│       ├── test_time_dependencies.json
│       └── test-archives
│           ├── archive.7z
│           ├── hello_world.tar.zst
│           └── hello_world.xar
└── Library
    ├── bin
    │   ├── archive.dll
    │   ├── bsdcat.exe
    │   ├── bsdcpio.exe
    │   └── bsdtar.exe
    ├── include
    │   ├── archive_entry.h
    │   └── archive.h
    ├── lib
    │   ├── archive_static.lib
    │   ├── archive.lib
    │   └── pkgconfig
    │       └── libarchive.pc
    └── share
        └── man
            ├── man1
            │   ├── bsdcat.1
            │   ├── bsdcpio.1
            │   └── bsdtar.1
            ├── man3
            │   ├── archive_entry_acl.3
            │   ├── archive_entry_linkify.3
            │   ├── archive_entry_misc.3
            │   ├── archive_entry_paths.3
            │   ├── archive_entry_perms.3
            │   ├── archive_entry_stat.3
            │   ├── archive_entry_time.3
            │   ├── archive_entry.3
            │   ├── archive_read_add_passphrase.3
            │   ├── archive_read_data.3
            │   ├── archive_read_disk.3
            │   ├── archive_read_extract.3
            │   ├── archive_read_filter.3
            │   ├── archive_read_format.3
            │   ├── archive_read_free.3
            │   ├── archive_read_header.3
            │   ├── archive_read_new.3
            │   ├── archive_read_open.3
            │   ├── archive_read_set_options.3
            │   ├── archive_read.3
            │   ├── archive_util.3
            │   ├── archive_write_blocksize.3
            │   ├── archive_write_data.3
            │   ├── archive_write_disk.3
            │   ├── archive_write_filter.3
            │   ├── archive_write_finish_entry.3
            │   ├── archive_write_format.3
            │   ├── archive_write_free.3
            │   ├── archive_write_header.3
            │   ├── archive_write_new.3
            │   ├── archive_write_open.3
            │   ├── archive_write_set_options.3
            │   ├── archive_write_set_passphrase.3
            │   ├── archive_write.3
            │   ├── libarchive_changes.3
            │   ├── libarchive_internals.3
            │   └── libarchive.3
            └── man5
                ├── cpio.5
                ├── libarchive-formats.5
                ├── mtree.5
                └── tar.5

18 directories, 76 files
```